### PR TITLE
New/add rule prefer use ref in function component

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,25 @@ own custom implementations of `acme-button`. For such cases you could limit usag
 CSS class to only e.g. `/components/Button.tsx` or `/components/Button.vue`. Of course, this only
 works if your CSS classes are specific enough.
 
+
+### prefer-useref-function-components
+Rule that warns if React.createRef() is used in a function component, instead of the preferred useRef hook.
+
+
+#### Configuration
+
+```json
+{
+    "rules": {
+        "moxio/prefer-useref-function-components": "warn",
+    }
+}
+```
+
+#### Motivation
+This plugin is mainly useful when switching from class components to function components. 
+
+
 Versioning
 ----------
 This project adheres to [Semantic Versioning](http://semver.org/).

--- a/lib/rules/prefer-useref-function-components.js
+++ b/lib/rules/prefer-useref-function-components.js
@@ -1,0 +1,61 @@
+/*global module*/
+/**
+ * @fileoverview Rule that reports errors if React.createRef is used inside function components
+ *
+ */
+
+"use strict";
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "In function components, the useRef hook should be used instead of createRef",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    schema: [],
+  },
+  create: function (context) {
+    return {
+      Identifier: function (node) {
+        const nodeType = node.name;
+        if (nodeType !== "createRef") {
+          return;
+        }
+        const isTestCase = findParent(node, (parent) => {
+          return (
+            parent.type === "CallExpression" && parent.callee.name === "it"
+          );
+        });
+
+        if (isTestCase) {
+          return;
+        }
+
+        const isFunction = findParent(
+          node,
+          (parent) =>
+            parent.type === "ArrowFunctionExpression" ||
+            parent.type === "FunctionDeclaration"
+        );
+        if (isFunction) {
+          context.report({
+            node: node,
+            message: "Prefer useRef hook in Function components.",
+          });
+        }
+      },
+    };
+  },
+};
+
+function findParent(node, testFn) {
+  if (testFn(node)) {
+    return node;
+  } else if (node.parent) {
+    return findParent(node.parent, testFn);
+  }
+  return null;
+}

--- a/tests/lib/rules/prefer-useref-function-components.js
+++ b/tests/lib/rules/prefer-useref-function-components.js
@@ -1,0 +1,75 @@
+/* global require */
+
+"use strict";
+
+const rule = require("../../../lib/rules/prefer-useref-function-components");
+const RuleTester = require("eslint").RuleTester;
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+const ERROR_MSG = "Prefer useRef hook in Function components.";
+
+ruleTester.run("prefer-useref-function-components", rule, {
+  valid: [
+    {
+      code: `const MyComponent = () => {
+                const ref = useRef();
+                return <div>valid</div>
+            }`,
+    },
+    {
+      code: `function MyComponent() {
+               const ref = useRef();
+                return <div>valid</div>
+            }`,
+    },
+    {
+      code: `class MyComponent extends React.Component {
+                constructor(props) {
+                    this.inputRef = React.createRef();
+                }
+                render() {
+                   return <input type="text" ref={this.inputRef} />;
+                }
+            }`,
+    },
+    {
+      code: `it("should be allowed in a test", () => {
+              const ref = React.createRef();
+             });`,
+    },
+  ],
+  invalid: [
+    {
+      code: `function MyComponent() {
+                const ref = React.createRef();
+                return <div>valid</div>
+            }`,
+      errors: [
+        {
+          message: ERROR_MSG,
+          type: "Identifier",
+        },
+      ],
+    },
+    {
+      code: `function MyComponent() {
+                const ref = React.createRef();
+                return <div>valid</div>
+            }`,
+      errors: [
+        {
+          message: ERROR_MSG,
+          type: "Identifier",
+        },
+      ],
+    },
+  ],
+});

--- a/tests/lib/rules/prefer-useref-function-components.js
+++ b/tests/lib/rules/prefer-useref-function-components.js
@@ -60,7 +60,7 @@ ruleTester.run("prefer-useref-function-components", rule, {
       ],
     },
     {
-      code: `function MyComponent() {
+      code: `const MyComponent = () => {
                 const ref = React.createRef();
                 return <div>valid</div>
             }`,


### PR DESCRIPTION
Adds a rule to warn against usage of React.createRef() in function components